### PR TITLE
Claude/explore conversation history 01 b3 k8 sjbc29 c ls k eog964 sn

### DIFF
--- a/_data/flashcards.json
+++ b/_data/flashcards.json
@@ -82,7 +82,7 @@
       "id": "cs-001",
       "type": "basic",
       "front": "What is the time complexity of binary search?",
-      "back": "O(log n) - each step halves the search space",
+      "back": "$O(\\log n)$ - each step halves the search space",
       "tags": ["cs", "algorithms", "complexity"],
       "source": "Example card",
       "created": "2025-12-06"
@@ -91,7 +91,7 @@
     {
       "id": "econ-micro-001",
       "type": "cloze",
-      "text": "{{Price elasticity of demand}} measures how much quantity demanded changes in response to a price change: %ΔQd / %ΔP.",
+      "text": "{{Price elasticity of demand}} measures how much quantity demanded changes in response to a price change: $\\frac{\\%\\Delta Q_d}{\\%\\Delta P}$.",
       "tags": ["econ", "micro", "elasticity"],
       "source": "Microeconomics fundamentals",
       "created": "2025-12-07"
@@ -99,7 +99,7 @@
     {
       "id": "econ-micro-002",
       "type": "basic",
-      "front": "What does it mean when demand is 'elastic' (|E| > 1)?",
+      "front": "What does it mean when demand is 'elastic' ($|E| > 1$)?",
       "back": "Quantity demanded changes more than proportionally to price. A 1% price increase causes >1% drop in quantity. Total revenue falls when price rises.",
       "tags": ["econ", "micro", "elasticity"],
       "source": "Microeconomics fundamentals",
@@ -141,8 +141,8 @@
     {
       "id": "econ-micro-007",
       "type": "basic",
-      "front": "Why does a monopolist produce where MR = MC rather than where P = MC?",
-      "back": "The monopolist faces a downward-sloping demand curve, so selling one more unit requires lowering the price on ALL units. MR < P because of this price effect. Producing where P = MC would mean MR < MC on the last unit - a loss.",
+      "front": "Why does a monopolist produce where $MR = MC$ rather than where $P = MC$?",
+      "back": "The monopolist faces a downward-sloping demand curve, so selling one more unit requires lowering the price on ALL units. $MR < P$ because of this price effect. Producing where $P = MC$ would mean $MR < MC$ on the last unit - a loss.",
       "tags": ["econ", "micro", "market-structures"],
       "source": "Microeconomics fundamentals",
       "created": "2025-12-07"
@@ -151,7 +151,7 @@
       "id": "econ-micro-008",
       "type": "reversible",
       "term": "Allocative efficiency",
-      "definition": "Achieved when P = MC; resources go to their highest-valued uses and total surplus is maximized",
+      "definition": "Achieved when $P = MC$; resources go to their highest-valued uses and total surplus is maximized",
       "tags": ["econ", "micro", "efficiency"],
       "source": "Microeconomics fundamentals",
       "created": "2025-12-07"
@@ -185,7 +185,7 @@
     {
       "id": "econ-micro-012",
       "type": "cloze",
-      "text": "In the long run, firms in perfect competition earn {{zero economic profit}} because positive profits attract entry until P = ATC.",
+      "text": "In the long run, firms in perfect competition earn {{zero economic profit}} because positive profits attract entry until $P = ATC$.",
       "tags": ["econ", "micro", "market-structures"],
       "source": "Microeconomics fundamentals",
       "created": "2025-12-07"
@@ -202,7 +202,7 @@
     {
       "id": "econ-micro-014",
       "type": "cloze",
-      "text": "At the optimal consumption bundle, {{MRS = price ratio}} (Px/Py), meaning the rate you're willing to trade equals the rate the market allows.",
+      "text": "At the optimal consumption bundle, {{$MRS = \\frac{P_x}{P_y}$}}, meaning the rate you're willing to trade equals the rate the market allows.",
       "tags": ["econ", "micro", "consumer-theory", "advanced"],
       "source": "Intermediate microeconomics",
       "created": "2025-12-07"
@@ -211,7 +211,7 @@
     {
       "id": "econ-macro-001",
       "type": "cloze",
-      "text": "GDP can be calculated three ways: {{expenditure}} (C+I+G+NX), {{income}} (wages+rent+interest+profit), and {{production}} (sum of value added).",
+      "text": "GDP can be calculated three ways: {{expenditure}} ($C + I + G + NX$), {{income}} (wages+rent+interest+profit), and {{production}} (sum of value added).",
       "tags": ["econ", "macro", "gdp"],
       "source": "Macroeconomics fundamentals",
       "created": "2025-12-07"
@@ -220,7 +220,7 @@
       "id": "econ-macro-002",
       "type": "basic",
       "front": "What's the difference between real and nominal GDP?",
-      "back": "Nominal GDP uses current prices; real GDP uses constant base-year prices. Real GDP removes inflation to show actual output changes. Real = Nominal / Price Level × 100.",
+      "back": "Nominal GDP uses current prices; real GDP uses constant base-year prices. Real GDP removes inflation to show actual output changes. $\\text{Real} = \\frac{\\text{Nominal}}{\\text{Price Level}} \\times 100$.",
       "tags": ["econ", "macro", "gdp"],
       "source": "Macroeconomics fundamentals",
       "created": "2025-12-07"
@@ -229,7 +229,7 @@
       "id": "econ-macro-003",
       "type": "reversible",
       "term": "GDP deflator",
-      "definition": "(Nominal GDP / Real GDP) × 100; measures the price level of all domestically produced goods, unlike CPI which measures a fixed consumer basket",
+      "definition": "$\\frac{\\text{Nominal GDP}}{\\text{Real GDP}} \\times 100$; measures the price level of all domestically produced goods, unlike CPI which measures a fixed consumer basket",
       "tags": ["econ", "macro", "inflation"],
       "source": "Macroeconomics fundamentals",
       "created": "2025-12-07"
@@ -262,7 +262,7 @@
     {
       "id": "econ-macro-007",
       "type": "cloze",
-      "text": "The {{money multiplier}} is 1/reserve ratio - it shows how much the money supply can expand from an initial deposit through fractional reserve banking.",
+      "text": "The {{money multiplier}} is $\\frac{1}{r}$ (where $r$ is the reserve ratio) - it shows how much the money supply can expand from an initial deposit through fractional reserve banking.",
       "tags": ["econ", "macro", "monetary-policy"],
       "source": "Macroeconomics fundamentals",
       "created": "2025-12-07"
@@ -305,7 +305,7 @@
     {
       "id": "econ-macro-012",
       "type": "cloze",
-      "text": "{{Okun's Law}} states that for every 1% unemployment rises above the natural rate, GDP falls about 2% below potential.",
+      "text": "{{Okun's Law}} states that for every $1\\%$ unemployment rises above the natural rate, GDP falls about $2\\%$ below potential.",
       "tags": ["econ", "macro", "unemployment", "advanced"],
       "source": "Intermediate macroeconomics",
       "created": "2025-12-07"
@@ -406,7 +406,7 @@
       "id": "econ-behavioral-001",
       "type": "reversible",
       "term": "Loss aversion",
-      "definition": "Losses loom larger than gains - people feel a loss about 2x as strongly as an equivalent gain, leading to risk-aversion for gains but risk-seeking to avoid losses",
+      "definition": "Losses loom larger than gains - people feel a loss about $2\\times$ as strongly as an equivalent gain, leading to risk-aversion for gains but risk-seeking to avoid losses",
       "tags": ["econ", "behavioral", "advanced"],
       "source": "Behavioral economics",
       "created": "2025-12-07"

--- a/assets/js/srs/ui.js
+++ b/assets/js/srs/ui.js
@@ -5,6 +5,24 @@
 
 import { Rating, getSchedulingOptions, formatInterval, getTimeUntilNextDue } from './fsrs.js';
 
+/**
+ * Render KaTeX math in an element if KaTeX is available
+ * @param {HTMLElement} element - Element to render math in
+ */
+function renderMath(element) {
+    if (typeof renderMathInElement === 'function') {
+        renderMathInElement(element, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "$", right: "$", display: false},
+                {left: "\\[", right: "\\]", display: true},
+                {left: "\\(", right: "\\)", display: false}
+            ],
+            throwOnError: false
+        });
+    }
+}
+
 // DOM element references
 let elements = {};
 
@@ -113,12 +131,14 @@ export function showCard(cardData, fsrsCard) {
     // Render front
     if (elements.cardFront) {
         elements.cardFront.innerHTML = cardData.front;
+        renderMath(elements.cardFront);
     }
 
     // Render back (hidden initially)
     if (elements.cardBack) {
         elements.cardBack.innerHTML = cardData.back;
         elements.cardBack.style.display = 'none';
+        renderMath(elements.cardBack);
     }
 
     // Show "Show Answer" button, hide rating buttons

--- a/docs/flashcard-format.md
+++ b/docs/flashcard-format.md
@@ -90,7 +90,10 @@ Use descriptive IDs: `topic-subtopic-NNN`
 - `latin`, `greek` - Classical languages
 - `philosophy`, `vocabulary` - Philosophy terms
 - `cs`, `algorithms`, `complexity` - Computer science
-- `history`, `econ` - History and economics
+- `econ`, `micro`, `macro` - Economics fundamentals
+- `game-theory`, `behavioral`, `information` - Advanced economics
+- `welfare`, `trade` - Welfare and international economics
+- `advanced` - Intermediate/advanced level concepts
 
 Check existing cards in `_data/flashcards.json` for consistent tagging.
 

--- a/docs/flashcard-format.md
+++ b/docs/flashcard-format.md
@@ -57,6 +57,26 @@ Cards are stored in `_data/flashcards.json`.
 4. **Use reversible** - For vocabulary and terms
 5. **Add context** - Enough to disambiguate, but keep concise
 
+## Math Support
+
+Cards support KaTeX for mathematical notation:
+- Inline math: `$E = mc^2$` renders as *E = mc²*
+- Display math: `$$\int_0^1 x^2 dx$$` renders centered on its own line
+- Works in front, back, text, term, and definition fields
+
+Example:
+```json
+{
+  "id": "math-001",
+  "type": "basic",
+  "front": "What is the quadratic formula?",
+  "back": "$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$",
+  "tags": ["math"],
+  "source": "Algebra",
+  "created": "2025-12-07"
+}
+```
+
 ## ID Convention
 
 Use descriptive IDs: `topic-subtopic-NNN`

--- a/learn.md
+++ b/learn.md
@@ -4,6 +4,7 @@ title: Learn
 description: Spaced repetition review system for long-term retention
 use_container: false
 srs: true
+math: true
 ---
 
 <div class="srs-container">


### PR DESCRIPTION
## Summary
- Add 44 intermediate-level economics flashcards covering micro, macro, game theory, behavioral economics, information economics, trade, and welfare
- Add KaTeX math rendering support to the flashcard/SRS system
- Update flashcard format documentation with math examples and expanded tag list

## Changes
- `_data/flashcards.json`: 44 new economics cards with proper LaTeX notation
- `assets/js/srs/ui.js`: Add `renderMath()` helper for KaTeX rendering
- `learn.md`: Enable math flag to load KaTeX
- `docs/flashcard-format.md`: Document math support and new tags

## Test plan
- [ ] Visit `/learn` and review cards with formulas (elasticity, GDP deflator, money multiplier)
- [ ] Verify math renders correctly (fractions, Greek letters, subscripts)
- [ ] Test tag filtering with new `econ`, `micro`, `macro` tags
